### PR TITLE
Tokens typo fix

### DIFF
--- a/src/content/components/kpi-cards/kpi-card-21.tsx
+++ b/src/content/components/kpi-cards/kpi-card-21.tsx
@@ -8,7 +8,7 @@ import { CategoryBar } from '@/components/CategoryBar';
 const data = [
   //array-start
   {
-    name: 'Average tokes per requests',
+    name: 'Average tokens per requests',
     total: '341',
     split: [136, 205],
     details: [

--- a/src/content/components/kpi-cards/kpi-card-22.tsx
+++ b/src/content/components/kpi-cards/kpi-card-22.tsx
@@ -6,7 +6,7 @@ import { ProgressBar } from '@/components/ProgressBar';
 const data = [
   //array-start
   {
-    name: 'Average tokes per requests',
+    name: 'Average tokens per requests',
     total: '341',
     details: [
       {

--- a/src/content/markdown/kpi-cards/kpi-card-21.mdx
+++ b/src/content/markdown/kpi-cards/kpi-card-21.mdx
@@ -9,7 +9,7 @@ import { CategoryBar } from '@/components/CategoryBar';
 const data = [
   //array-start
   {
-    name: 'Average tokes per requests',
+    name: 'Average tokens per requests',
     total: '341',
     split: [136, 205],
     details: [

--- a/src/content/markdown/kpi-cards/kpi-card-22.mdx
+++ b/src/content/markdown/kpi-cards/kpi-card-22.mdx
@@ -7,7 +7,7 @@ import { ProgressBar } from '@/components/ProgressBar';
 const data = [
   //array-start
   {
-    name: 'Average tokes per requests',
+    name: 'Average tokens per requests',
     total: '341',
     details: [
       {


### PR DESCRIPTION
Noticed that the docs cited "tokes" instead of "tokens" in a few places. Just a small typo fix that resolves this!